### PR TITLE
Add option for stripping a strict prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ main = BL.putStrLn $ encode testData
 `Deriving.Aeson.Stock` contains some aliases for even less boilerplates.
 
 * `Prefixed str` = `CustomJSON '[FieldLabelModifier (StripPrefix str)]`
+* `Prefixed' str` = `CustomJSON '[FieldLabelModifier (StripStrictPrefix str)]`
 * `PrefixedSnake str` = `CustomJSON '[FieldLabelModifier (StripPrefix str, CamelToSnake)]`
+* `PrefixedSnake str` = `CustomJSON '[FieldLabelModifier (StripStrictPrefix str, CamelToSnake)]`
 * `Snake` = `CustomJSON '[FieldLabelModifier (StripPrefix str, CamelToSnake)]`
 * `Vanilla` = `CustomJSON '[]`
 

--- a/src/Deriving/Aeson/Stock.hs
+++ b/src/Deriving/Aeson/Stock.hs
@@ -4,6 +4,8 @@
 module Deriving.Aeson.Stock
   ( Prefixed
   , PrefixedSnake
+  , Prefixed'
+  , PrefixedSnake'
   , Snake
   , Vanilla
   -- * Reexports
@@ -17,8 +19,14 @@ import Deriving.Aeson
 -- | Field names are prefixed by @str@; strip them from JSON representation
 type Prefixed str = CustomJSON '[FieldLabelModifier (StripPrefix str)]
 
+-- | Field names are strictly prefixed by @str@; strip them from JSON representation
+type Prefixed' str = CustomJSON '[FieldLabelModifier (StripStrictPrefix str)]
+
 -- | Strip @str@ prefices and convert from CamelCase to snake_case
 type PrefixedSnake str = CustomJSON '[FieldLabelModifier (StripPrefix str, CamelToSnake)]
+
+-- | Strip @str@ strict prefixes and convert from CamelCase to snake_case
+type PrefixedSnake' str = CustomJSON '[FieldLabelModifier (StripStrictPrefix str, CamelToSnake)]
 
 -- | Convert from CamelCase to snake_case
 type Snake = CustomJSON '[FieldLabelModifier CamelToSnake]


### PR DESCRIPTION
string a is string b's strict prefix iff a is b's prefix and the result string is empty or its first character is not lower case alphabetic.
motivation:
For example, I need a record `User` with two fields `id` and `username`, I could write it as
```
data User =
  User
    { userId :: Text
    , userUsername :: Text
    }
```
and use PrefixSnake, but `userUsername` is really unnatural. Strict prefix solves this problem.