### PR TITLE
Bump version following minor upgrade

### DIFF
--- a/deriving-aeson.cabal
+++ b/deriving-aeson.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                deriving-aeson
-version:             0.2.4
+version:             0.2.5
 synopsis:            Type driven generic aeson instance customisation
 description:         This package provides a newtype wrapper with
   FromJSON/ToJSON instances customisable via a phantom type parameter.


### PR DESCRIPTION
I forgot to update the library version in my recently merged PR: https://github.com/fumieval/deriving-aeson/pull/9

I hope the new version will make it to hackage.