### PR TITLE
add StringModifier instance to lists of StringModifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ data User = User
   , userAPIToken :: Maybe String
   } deriving Generic
   deriving (FromJSON, ToJSON)
-  via CustomJSON '[OmitNothingFields, FieldLabelModifier (StripPrefix "user", CamelToSnake)] User
+  via CustomJSON '[OmitNothingFields, FieldLabelModifier '[StripPrefix "user", CamelToSnake]] User
 
 testData :: [User]
 testData = [User 42 "Alice" Nothing, User 43 "Bob" (Just "xyz")]
@@ -36,7 +36,7 @@ main = BL.putStrLn $ encode testData
 
 * `Prefixed str` = `CustomJSON '[FieldLabelModifier (StripPrefix str)]`
 * `PrefixedSnake str` = `CustomJSON '[FieldLabelModifier (StripPrefix str, CamelToSnake)]`
-* `Snake` = `CustomJSON '[FieldLabelModifier (StripPrefix str, CamelToSnake)]`
+* `Snake` = `CustomJSON '[FieldLabelModifier '[StripPrefix str, CamelToSnake]]`
 * `Vanilla` = `CustomJSON '[]`
 
 How it works

--- a/src/Deriving/Aeson.hs
+++ b/src/Deriving/Aeson.hs
@@ -102,6 +102,13 @@ class StringModifier t where
 instance KnownSymbol k => StringModifier (StripPrefix k) where
   getStringModifier = fromMaybe <*> stripPrefix (symbolVal (Proxy @k))
 
+instance StringModifier '[] where
+  getStringModifier = id
+
+-- | Left-to-right (@'foldr' ('flip' ('.')) 'id'@) composition
+instance (StringModifier a, StringModifier as) => StringModifier (a ': as) where
+  getStringModifier = getStringModifier @as . getStringModifier @a
+
 -- | Left-to-right (@'flip' '.'@) composition
 instance (StringModifier a, StringModifier b) => StringModifier (a, b) where
   getStringModifier = getStringModifier @b . getStringModifier @a

--- a/src/Deriving/Aeson/Stock.hs
+++ b/src/Deriving/Aeson/Stock.hs
@@ -18,7 +18,7 @@ import Deriving.Aeson
 type Prefixed str = CustomJSON '[FieldLabelModifier (StripPrefix str)]
 
 -- | Strip @str@ prefices and convert from CamelCase to snake_case
-type PrefixedSnake str = CustomJSON '[FieldLabelModifier (StripPrefix str, CamelToSnake)]
+type PrefixedSnake str = CustomJSON '[FieldLabelModifier '[StripPrefix str, CamelToSnake]]
 
 -- | Convert from CamelCase to snake_case
 type Snake = CustomJSON '[FieldLabelModifier CamelToSnake]

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -14,7 +14,7 @@ data User = User
   , userAPIToken :: Maybe String
   } deriving Generic
   deriving (FromJSON, ToJSON)
-  via CustomJSON '[OmitNothingFields, FieldLabelModifier (StripPrefix "user", CamelToSnake)] User
+  via CustomJSON '[OmitNothingFields, FieldLabelModifier '[StripPrefix "user", CamelToSnake]] User
 
 data Foo = Foo { fooFoo :: Int, fooBar :: Int }
   deriving Generic


### PR DESCRIPTION
This works more generally than the tuple instances, and is similar to what `CustomJSON` already does.

One could even remove the tuple instances, but it is probably a good idea to (at least) wait for other breaking changes.