### PR TITLE
Fix build on GHC 9.2

### DIFF
--- a/src/Deriving/Aeson/Stock.hs
+++ b/src/Deriving/Aeson/Stock.hs
@@ -12,6 +12,7 @@ module Deriving.Aeson.Stock
   , ToJSON
   , Generic) where
 
+import Data.Kind (Type)
 import Deriving.Aeson
 
 -- | Field names are prefixed by @str@; strip them from JSON representation
@@ -24,4 +25,4 @@ type PrefixedSnake str = CustomJSON '[FieldLabelModifier '[StripPrefix str, Came
 type Snake = CustomJSON '[FieldLabelModifier CamelToSnake]
 
 -- | No customisation
-type Vanilla = CustomJSON '[]
+type Vanilla = CustomJSON ('[] :: [Type])


### PR DESCRIPTION
Depends on https://github.com/haskell/aeson/issues/885

Fixes this compilation error:
```
src/Deriving/Aeson/Stock.hs:27:1: error:
    • Uninferrable type variable k0 in
      the type synonym right-hand side: CustomJSON @{[k0]} ('[] @k0)
    • In the type declaration for ‘Vanilla’
   |
27 | type Vanilla = CustomJSON '[]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```