### PR TITLE
Allow aeson 2.3

### DIFF
--- a/deriving-aeson.cabal
+++ b/deriving-aeson.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:
     Deriving.Aeson
     Deriving.Aeson.Stock
-  build-depends:       base >= 4.12 && <5, aeson >= 1.4.7.0 && <2.3
+  build-depends:       base >= 4.12 && <5, aeson >= 1.4.7.0 && <2.4
   hs-source-dirs: src
   default-language:    Haskell2010
   ghc-options: -Wall -Wcompat


### PR DESCRIPTION
Builds fine and all tests pass.

`aeson 2.3.0.0` has breaking changes in the `FromJSON` instances for `Fixed`,
`DiffTime`, and `NominalDiffTime`, but they do not affect deriving-aeson,
which only relies on the Generic-based machinery.
